### PR TITLE
Allow Encrypted Password Storage In Database

### DIFF
--- a/Tracker_Database.sql
+++ b/Tracker_Database.sql
@@ -30,13 +30,14 @@ CREATE TABLE rangers (
 DROP TABLE IF EXISTS accounts;
 CREATE TABLE accounts (
 	ID char(10) not null,
-    rangerpassword varchar(30) not null,
+    rangerpassword char(64) not null,
+    salt char(16) not null,
     IsAdmin boolean not null,
     primary key (ID),
 	CONSTRAINT login_fk1 foreign key (ID) references rangers (dodID) on delete cascade on update cascade
     );
     
-    insert into accounts values ('1234567890', 'password', false);
+    insert into accounts values ('1234567890', '8f3a511d285261635c4dca95c3e4decb692ab58d7cb814d14822617374999789', 'abcdefghijklnmop', false);
     
 DROP TABLE IF EXISTS srp_files;
 CREATE TABLE srp_files (
@@ -107,11 +108,11 @@ delimiter ;
 
 drop procedure if exists add_account;
 delimiter //
-create procedure add_account(in ip_ID char(10), in ip_rangerpassword varchar(30), in ip_IsAdmin boolean)
+create procedure add_account(in ip_ID char(10), in ip_rangerpassword char(64), in ip_salt char(16), in ip_IsAdmin boolean)
 sp_main: begin
 	if ((ip_ID in (select ID from accounts)) or (ip_ID not in (select dodID from rangers)))
     then leave sp_main; end if;
-    insert into accounts values (ip_ID, ip_rangerpassword, ip_IsAdmin);
+    insert into accounts values (ip_ID, ip_rangerpassword, ip_salt, ip_IsAdmin);
 end //
 delimiter ;
 -- Empty inputs can be rendered as '' to not sort by that input


### PR DESCRIPTION
Changes rangerpassword field of account table to 64 char encrypted input, and adds a field for taking in the password's salt string